### PR TITLE
Enable cross-platform and any network interface names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Expand your Cozmo's abilities with this Scratch extension. With Scratch's drag-a
 2. Install extra python libraries
 
 ```
-$ pip3 install --user tornado pillow numpy cozmo[camera]
+$ pip3 install --user tornado pillow numpy cozmo[camera] netifaces
 ```
 
 3. Connect Cozmo to your phone/tablet with the app

--- a/controller/server.py
+++ b/controller/server.py
@@ -11,27 +11,23 @@ except ImportError:
 import webbrowser
 import os
 import socket
-
-if os.name != "nt":
-    import fcntl
-    import struct
-    def get_interface_ip(ifname):
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        return socket.inet_ntoa(fcntl.ioctl(s.fileno(), 0x8915, struct.pack('256s',ifname[:15]))[20:24])
+import netifaces
 
 def get_lan_ip():
     ip = socket.gethostbyname(socket.gethostname())
     if ip.startswith("127.") and os.name != "nt":
-        interfaces = ["eth0","eth1","eth2","wlan0","wlan1","wifi0","ath0","ath1","ppp0",]
-        for ifname in interfaces:
-            try:
-                ip = get_interface_ip(ifname)
-                break
-            except IOError:
-                pass
+        ifaces = netifaces.interfaces()
+        for ifname in ifaces:
+            ifacesInfo = netifaces.ifaddresses(ifname)
+            for info in ifacesInfo[netifaces.AF_INET]:
+                addr = info['addr']
+                if not addr.startswith("127.") and not addr == '0.0.0.0':
+                    return addr
+        raise Exception("Unable determine IP address")
     return ip
 
 serverIP = get_lan_ip()
+print("Server IP address determined as {}".format(serverIP))
 clients = []
 apps = []
 robotStatus = False


### PR DESCRIPTION
This enables any network interface names, e.g. on Ubuntu 16.04 in a VirtualBox interface name could be ```enp0s3```). Also, on Mac interfaces would be completely different.